### PR TITLE
Remove codecov from workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,5 +56,3 @@ jobs:
       - name: Run tests
         run: SCOPE="${{ matrix.package }}" dart run melos test:ci
 
-      - name: Upload coverage to codecov
-        run: curl -s https://codecov.io/bash | bash


### PR DESCRIPTION
Removing codecov from workflow as we are going to use the GH app instead.