### PR TITLE
[provider] fix subscriptions

### DIFF
--- a/packages/polkadart/lib/provider.dart
+++ b/packages/polkadart/lib/provider.dart
@@ -13,11 +13,11 @@ class RpcResponse<R, T> {
   RpcResponse({required this.id, this.result, this.error});
 }
 
-class SubscriptionReponse<R> {
+class SubscriptionResponse<R> {
   final String id;
   final Stream<SubscriptionMessage<R>> stream;
 
-  SubscriptionReponse({required this.id, required this.stream});
+  SubscriptionResponse({required this.id, required this.stream});
 }
 
 class SubscriptionMessage<R> {
@@ -56,7 +56,7 @@ abstract class Provider {
   Future<RpcResponse> send(String method, List<dynamic> params);
 
   /// Send subscribe message to RPC node
-  Future<SubscriptionReponse> subscribe(String method, List<dynamic> params,
+  Future<SubscriptionResponse> subscribe(String method, List<dynamic> params,
       {FutureOr<void> Function(String subscription)? onCancel});
 }
 
@@ -89,7 +89,7 @@ class HttpProvider extends Provider {
   }
 
   @override
-  Future<SubscriptionReponse> subscribe(String method, List params,
+  Future<SubscriptionResponse> subscribe(String method, List params,
       {FutureOr<void> Function(String subscription)? onCancel}) {
     throw Exception('HttpProvider does not support subscriptions');
   }
@@ -244,7 +244,7 @@ class WsProvider extends Provider {
 
   /// Send arbitrary message to RPC node
   @override
-  Future<SubscriptionReponse> subscribe(String method, List<dynamic> params,
+  Future<SubscriptionResponse> subscribe(String method, List<dynamic> params,
       {FutureOr<void> Function(String subscription)? onCancel}) async {
     // print('Subscribing to method: $method');
     final result = await send(method, params);
@@ -255,7 +255,7 @@ class WsProvider extends Provider {
 
     final subscription = result.result as String;
     final controller = getOrCreateSubscriptionController(subscription);
-    return SubscriptionReponse(
+    return SubscriptionResponse(
       id: subscription,
       stream: controller.stream,
     );

--- a/packages/polkadart/lib/provider.dart
+++ b/packages/polkadart/lib/provider.dart
@@ -252,6 +252,11 @@ class WsProvider extends Provider {
   Future<SubscriptionReponse> subscribe(String method, List<dynamic> params,
       {FutureOr<void> Function(String subscription)? onCancel}) async {
     final result = await send(method, params);
+
+    if (result.error != null) {
+      throw Exception(result.error.toString());
+    }
+
     final subscription = result.result as String;
     final controller = getOrCreateSubscriptionController(method, subscription);
     return SubscriptionReponse(

--- a/packages/polkadart/lib/provider.dart
+++ b/packages/polkadart/lib/provider.dart
@@ -197,7 +197,7 @@ class WsProvider extends Provider {
       final method = message['method'] as String;
       final params = message['params'] as Map<String, dynamic>;
       final subscription = params['subscription'] as String;
-      final result = params.containsKey('result') ? message['result'] : null;
+      final result = params.containsKey('result') ? params['result'] : null;
       return SubscriptionMessage(
           method: method, subscription: subscription, result: result);
     }).listen((message) {

--- a/packages/polkadart/test/apis/mock_provider.dart
+++ b/packages/polkadart/test/apis/mock_provider.dart
@@ -1,6 +1,6 @@
 import 'dart:async' show Future, FutureOr;
 import 'package:polkadart/polkadart.dart'
-    show Provider, RpcResponse, SubscriptionReponse;
+    show Provider, RpcResponse, SubscriptionResponse;
 
 /// The Mock Provider allows mock requests.
 class MockProvider<S> extends Provider {
@@ -35,7 +35,7 @@ class MockProvider<S> extends Provider {
   }
 
   @override
-  Future<SubscriptionReponse> subscribe(String method, List params,
+  Future<SubscriptionResponse> subscribe(String method, List params,
       {FutureOr<void> Function(String subscription)? onCancel}) {
     throw Exception('MockProvider does not support subscriptions');
   }


### PR DESCRIPTION
Closes #338. So the problem is that the method name returned in subscription names doesn't match the method name that is used to actually subscribe; hence we were unable to get the correct stream controller in the subscription messages. This PR fixes it in a way that we introduce a map that uses purely the subscription ID, to identify the stream controller.