### PR TITLE
Update xxh64.dart to fix run in chrome hash error

### DIFF
--- a/packages/polkadart/lib/substrate/xxh64.dart
+++ b/packages/polkadart/lib/substrate/xxh64.dart
@@ -94,7 +94,7 @@ class XXH64 {
 
     for (int i = 0; i < size; i++) {
       // block |= BigInt.from(array[index + i] << (i * 8)).toUnsigned(64);
-      var item = BigInt.from(array[index + i]);
+      final item = BigInt.from(array[index + i]);
       block |= (item << (i * 8)).toUnsigned(64);
     }
     if (endian == Endian.little) {

--- a/packages/polkadart/lib/substrate/xxh64.dart
+++ b/packages/polkadart/lib/substrate/xxh64.dart
@@ -93,7 +93,9 @@ class XXH64 {
     final size = array.length - index;
 
     for (int i = 0; i < size; i++) {
-      block |= BigInt.from(array[index + i] << (i * 8)).toUnsigned(64);
+      // block |= BigInt.from(array[index + i] << (i * 8)).toUnsigned(64);
+      var item = BigInt.from(array[index + i]);
+      block |= (item << (i * 8)).toUnsigned(64);
     }
     if (endian == Endian.little) {
       return block;


### PR DESCRIPTION
I tried running polkadart in a web environment and found that xxh64 was not working properly, so I found the issue and tried to fix it. If possible, please check this PR for any potential side effects during the certification process. Thank you.