### PR TITLE
[CI] fail if fmt is wrong and check `polkadart_example`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,7 +55,7 @@ jobs:
         if: ${{ matrix.package == 'polkadart_example' }}
         # Format the generated files so that they don't make the CI fail afterwards.
         run: |
-          dart run polkadart_cli:generate -v
+          cd examples && dart run polkadart_cli:generate -v
           dart format examples/lib/generated
 
       - name: Check format

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,7 @@ jobs:
         package:
           - polkadart
           - polkadart_cli
+          - polkadart_example
           - polkadart_keyring
           - polkadart_scale_codec
           - ss58

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,10 +53,7 @@ jobs:
 
       - name: Generate Files for polkadart_example
         if: ${{ matrix.package == 'polkadart_example' }}
-        # Format the generated files so that they don't make the CI fail afterwards.
-        run: |
-          cd examples && dart run polkadart_cli:generate -v
-          dart format examples/lib/generated
+        run: cd examples && dart run polkadart_cli:generate -v
 
       - name: Check format
         run: SCOPE="${{ matrix.package }}" dart run melos format

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,6 +51,13 @@ jobs:
         env:
           MELOS_SDK_PATH: ${{ env.FLUTTER_ROOT }}
 
+      - name: Generate Files for polkadart_example
+        if: ${{ matrix.package == 'polkadart_example' }}
+        # Format the generated files so that they don't make the CI fail afterwards.
+        run: |
+          dart run polkadart_cli:generate -v
+          dart format examples/lib/generated
+
       - name: Check format
         run: SCOPE="${{ matrix.package }}" dart run melos format
 

--- a/examples/bin/get_account_infos_demo.dart
+++ b/examples/bin/get_account_infos_demo.dart
@@ -10,17 +10,22 @@ Future<void> main(List<String> arguments) async {
   final polkadot = Polkadot(provider);
 
   final accountMapPrefix = polkadot.query.system.accountMapPrefix();
-  final keys = await polkadot.rpc.state.getKeysPaged(key: accountMapPrefix, count: 10);
+  final keys =
+      await polkadot.rpc.state.getKeysPaged(key: accountMapPrefix, count: 10);
 
-  print("First 10 account storage keys: ${keys.map((key) => '0x${hex.encode(key)}')}");
+  print(
+      "First 10 account storage keys: ${keys.map((key) => '0x${hex.encode(key)}')}");
 
   // Decoding of the keys has to be done manually for now, see how substrate storage keys are defined:
   // https://www.shawntabrizi.com/blog/substrate/transparent-keys-in-substrate/
-  final accountIds = keys.map((key) => const AccountId32Codec().decode(ByteInput(key.sublist(32))));
-  print("First 10 account pubKeys: ${accountIds.map((account) => '0x${hex.encode(account)}')}");
+  final accountIds = keys.map(
+      (key) => const AccountId32Codec().decode(ByteInput(key.sublist(32))));
+  print(
+      "First 10 account pubKeys: ${accountIds.map((account) => '0x${hex.encode(account)}')}");
 
   // Get `AccountInfo`s of those keys
-  final accountInfos = await Future.wait(accountIds.map((account) => polkadot.query.system.account(account)));
+  final accountInfos = await Future.wait(
+      accountIds.map((account) => polkadot.query.system.account(account)));
 
   for (final accountInfo in accountInfos) {
     print('AccountInfo: ${accountInfo.toJson()}');

--- a/examples/test/mock_test.dart
+++ b/examples/test/mock_test.dart
@@ -1,0 +1,7 @@
+import 'package:test/test.dart';
+
+void main() {
+    test('Mock test, as melos expects at least a test. Otherwise it returns an error.', () {
+      expect(true, true);
+    });
+}

--- a/examples/test/mock_test.dart
+++ b/examples/test/mock_test.dart
@@ -1,7 +1,9 @@
 import 'package:test/test.dart';
 
 void main() {
-    test('Mock test, as melos expects at least a test. Otherwise it returns an error.', () {
-      expect(true, true);
-    });
+  test(
+      'Mock test, as melos expects at least a test. Otherwise it returns an error.',
+      () {
+    expect(true, true);
+  });
 }

--- a/melos.yaml
+++ b/melos.yaml
@@ -17,7 +17,7 @@ scripts:
     run: dart run melos exec --scope="${SCOPE:-*}" -c 1 --fail-fast -- 'dart run coverage:format_coverage --lcov --in=coverage --out=coverage/coverage.lcov --packages=.dart_tool/package_config.json --report-on=lib'
   
   format:
-    run: dart run melos exec --scope="${SCOPE:-*}" -c 1 --fail-fast -- 'dart format .'
+    run: dart run melos exec --scope="${SCOPE:-*}" -c 1 --fail-fast -- 'dart format . --set-exit-if-changed'
   
   analyze:
     run: dart run melos exec --scope="${SCOPE:-*}" -c 1 --fail-fast -- 'dart analyze --fatal-infos .'

--- a/packages/polkadart/lib/apis/state.dart
+++ b/packages/polkadart/lib/apis/state.dart
@@ -190,8 +190,7 @@ class StateApi<P extends Provider> {
 
   /// Subscribes to storage changes for the provided keys
   Future<StreamSubscription<StorageChangeSet>> subscribeStorage(
-      List<Uint8List> storageKeys,
-      Function(StorageChangeSet) onData) async {
+      List<Uint8List> storageKeys, Function(StorageChangeSet) onData) async {
     final hexKeys = storageKeys.map((key) => '0x${hex.encode(key)}').toList();
     final subscription = await _provider.subscribe(
         'state_subscribeStorage', [hexKeys], onCancel: (subscription) async {

--- a/packages/polkadart/lib/substrate/storage.dart
+++ b/packages/polkadart/lib/substrate/storage.dart
@@ -157,7 +157,8 @@ class StorageDoubleMap<K1, K2, V> {
   });
 
   Uint8List hashedKeyFor(K1 key1, K2 key2) {
-    final Uint8List hash = Uint8List(32 + hasher1.size(key1) + hasher2.size(key2));
+    final Uint8List hash =
+        Uint8List(32 + hasher1.size(key1) + hasher2.size(key2));
     _hashPrefixTo(key1, output: hash);
 
     final cursor = hash.offsetInBytes + 32 + hasher1.size(key1);

--- a/packages/polkadart_cli/lib/src/generator/pallet.dart
+++ b/packages/polkadart_cli/lib/src/generator/pallet.dart
@@ -448,8 +448,7 @@ Class createPalletQueries(
                       ..name = 'key${storage.hashers.indexOf(hasher) + 1}')))
                 ..body = Block((b) => b
                   // final hashedKey = _storageName.hashedKeyFor(key1);
-                  ..statements
-                      .add(declareFinal('hashedKey')
+                  ..statements.add(declareFinal('hashedKey')
                       .assignHashedKey(storageName, storage)
                       .statement)
                   // final bytes = await api.queryStorage([hashedKey]);
@@ -475,44 +474,47 @@ Class createPalletQueries(
                       storage.isNullable ? Code('') : Code('/* Default */')));
             })))
         ..methods.addAll(generator.storages.map((storage) => Method((builder) {
-          final storageName = ReCase(storage.name).camelCase;
-          builder
-            ..name = sanitize(storage.keyMethodName(), recase: false)
-            ..docs.addAll(sanitizeDocs(['Returns the storage key for `$storageName`.']))
-            ..returns = refs.uint8List
-            ..requiredParameters
-                .addAll(storage.hashers.map((hasher) => Parameter((b) => b
-              ..type = hasher.codec.primitive(dirname)
-              ..name = 'key${storage.hashers.indexOf(hasher) + 1}')))
-            ..body = Block((b) => b
-              ..statements
-                  .add(declareFinal('hashedKey')
-                  .assignHashedKey(storageName, storage)
-                  .statement)
-              ..statements
-                  .add(Code('  return hashedKey;')));
-        })))
+              final storageName = ReCase(storage.name).camelCase;
+              builder
+                ..name = sanitize(storage.keyMethodName(), recase: false)
+                ..docs.addAll(sanitizeDocs(
+                    ['Returns the storage key for `$storageName`.']))
+                ..returns = refs.uint8List
+                ..requiredParameters
+                    .addAll(storage.hashers.map((hasher) => Parameter((b) => b
+                      ..type = hasher.codec.primitive(dirname)
+                      ..name = 'key${storage.hashers.indexOf(hasher) + 1}')))
+                ..body = Block((b) => b
+                  ..statements.add(declareFinal('hashedKey')
+                      .assignHashedKey(storageName, storage)
+                      .statement)
+                  ..statements.add(Code('  return hashedKey;')));
+            })))
         ..methods.addAll(generator.storages
             // We don't support maps with depth > 2 yet.
-            .where((storage) => storage.hashers.isNotEmpty && storage.hashers.length < 3)
+            .where((storage) =>
+                storage.hashers.isNotEmpty && storage.hashers.length < 3)
             .map((storage) => Method((builder) {
-          final storageName = ReCase(storage.name).camelCase;
-          builder
-            ..name = sanitize(storage.mapPrefixMethodName(), recase: false)
-            ..docs.addAll(sanitizeDocs(['Returns the storage map key prefix for `$storageName`.']))
-            ..returns = refs.uint8List
-            ..requiredParameters
-                .addAll(storage.hashers.getRange(0, storage.hashers.length - 1).map((hasher) => Parameter((b) => b
-              ..type = hasher.codec.primitive(dirname)
-              ..name = 'key${storage.hashers.indexOf(hasher) + 1}')))
-            ..body = Block((b) => b
-              ..statements
-                  .add(declareFinal('hashedKey')
-                  .assignMapPrefix(storageName, storage)
-                  .statement)
-              ..statements
-                  .add(Code('  return hashedKey;')));
-        })));
+                  final storageName = ReCase(storage.name).camelCase;
+                  builder
+                    ..name =
+                        sanitize(storage.mapPrefixMethodName(), recase: false)
+                    ..docs.addAll(sanitizeDocs([
+                      'Returns the storage map key prefix for `$storageName`.'
+                    ]))
+                    ..returns = refs.uint8List
+                    ..requiredParameters.addAll(storage.hashers
+                        .getRange(0, storage.hashers.length - 1)
+                        .map((hasher) => Parameter((b) => b
+                          ..type = hasher.codec.primitive(dirname)
+                          ..name =
+                              'key${storage.hashers.indexOf(hasher) + 1}')))
+                    ..body = Block((b) => b
+                      ..statements.add(declareFinal('hashedKey')
+                          .assignMapPrefix(storageName, storage)
+                          .statement)
+                      ..statements.add(Code('  return hashedKey;')));
+                })));
     });
 
 Class createPalletTxs(
@@ -597,7 +599,6 @@ Class createPalletConstants(
     });
 
 extension MethodNameExtension on Storage {
-
   /// Name of the generated method returning the key of a storage.
   String keyMethodName() {
     return '${name}Key';
@@ -612,11 +613,9 @@ extension MethodNameExtension on Storage {
 extension AssignHashedKeyExtension on Expression {
   Expression assignHashedKey(String storageName, Storage storage) {
     return assign(refer('_$storageName')
-        .property(storage.hashers.isEmpty
-        ? 'hashedKey'
-        : 'hashedKeyFor')
-        .call(storage.hashers.map((hasher) => refer(
-        'key${storage.hashers.indexOf(hasher) + 1}'))));
+        .property(storage.hashers.isEmpty ? 'hashedKey' : 'hashedKeyFor')
+        .call(storage.hashers.map(
+            (hasher) => refer('key${storage.hashers.indexOf(hasher) + 1}'))));
   }
 
   Expression assignMapPrefix(String storageName, Storage storage) {
@@ -632,14 +631,10 @@ extension AssignHashedKeyExtension on Expression {
       );
     }
 
-    return assign(refer('_$storageName')
-        .property('mapPrefix')
-        .call(storage.hashers
+    return assign(refer('_$storageName').property('mapPrefix').call(storage
+        .hashers
         // Checked above that hasher is not empty.
         .getRange(0, storage.hashers.length - 1)
-        .map((hasher) => refer(
-        'key${storage.hashers.indexOf(hasher) + 1}'))));
+        .map((hasher) => refer('key${storage.hashers.indexOf(hasher) + 1}'))));
   }
 }
-
-


### PR DESCRIPTION
This PR introduces the following changes:
* The fmt CI command didn't return an error if there were badly formatted fails, this is changed now.
* Check the code of the `polkadart_example` in the CI. This means that we also generate the types for Polkadot in the CI.