### PR TITLE
Add sign method

### DIFF
--- a/examples/bin/extrinsic_demo.dart
+++ b/examples/bin/extrinsic_demo.dart
@@ -30,7 +30,7 @@ Future<void> main(List<String> arguments) async {
       .result
       .replaceAll('0x', '');
 
-  final keyring = await KeyPair.fromMnemonic(
+  final keyring = await KeyPair.sr25519.fromMnemonic(
       "resource mirror lecture smooth midnight muffin position cup pepper fruit vanish also//0"); // This is a random key
 
   final publicKey = hex.encode(keyring.publicKey.bytes);

--- a/examples/bin/extrinsic_demo.dart
+++ b/examples/bin/extrinsic_demo.dart
@@ -1,6 +1,12 @@
 import 'package:convert/convert.dart';
 import 'package:polkadart/polkadart.dart'
-    show AuthorApi, Extrinsic, Provider, SigningPayload, StateApi;
+    show
+        AuthorApi,
+        Extrinsic,
+        Provider,
+        SignatureType,
+        SigningPayload,
+        StateApi;
 import 'package:polkadart_keyring/polkadart_keyring.dart';
 
 import 'package:polkadart_example/generated/polkadot/polkadot.dart';
@@ -67,7 +73,7 @@ Future<void> main(List<String> arguments) async {
     blockNumber: blockNumber,
     nonce: 0,
     tip: 0,
-  ).encode(api.registry);
+  ).encode(api.registry, SignatureType.sr25519);
 
   final hexExtrinsic = hex.encode(extrinsic);
   print('Extrinsic: $hexExtrinsic');

--- a/packages/polkadart/lib/extrinsic/extrinsic.dart
+++ b/packages/polkadart/lib/extrinsic/extrinsic.dart
@@ -1,2 +1,3 @@
 export 'signing_payload.dart';
 export 'extrinsic_payload.dart';
+export 'signature_type.dart';

--- a/packages/polkadart/lib/extrinsic/signature_type.dart
+++ b/packages/polkadart/lib/extrinsic/signature_type.dart
@@ -1,0 +1,16 @@
+import 'dart:typed_data';
+import 'package:polkadart_keyring/polkadart_keyring.dart' as keyring;
+
+enum SignatureType {
+  ed25519('00'),
+  sr25519('01');
+
+  final String type;
+  const SignatureType(this.type);
+}
+
+extension SignExtrinsicExtension on Uint8List {
+  Uint8List sign(keyring.KeyPair keyPair) {
+    return keyPair.sign(this);
+  }
+}

--- a/packages/polkadart/lib/extrinsic/signed_extensions/asset_hub.dart
+++ b/packages/polkadart/lib/extrinsic/signed_extensions/asset_hub.dart
@@ -1,5 +1,15 @@
-class AssetHubSignedExtensions {
-  static String signedExtension(String extension, Map info) {
+import 'package:polkadart/extrinsic/signed_extensions/signed_extensions_abstract.dart';
+
+class AssetHubSignedExtensions implements SignedExtensions {
+  static final AssetHubSignedExtensions _instance =
+      AssetHubSignedExtensions._internal();
+
+  factory AssetHubSignedExtensions() => _instance;
+
+  AssetHubSignedExtensions._internal();
+
+  @override
+  String signedExtension(String extension, Map info) {
     switch (extension) {
       case 'CheckMortality':
         return info['era'];
@@ -12,7 +22,8 @@ class AssetHubSignedExtensions {
     }
   }
 
-  static String additionalSignedExtension(String extension, Map info) {
+  @override
+  String additionalSignedExtension(String extension, Map info) {
     switch (extension) {
       case 'CheckNonce':
         return info['nonce'];

--- a/packages/polkadart/lib/extrinsic/signed_extensions/signed_extensions_abstract.dart
+++ b/packages/polkadart/lib/extrinsic/signed_extensions/signed_extensions_abstract.dart
@@ -1,0 +1,12 @@
+import 'package:polkadart/extrinsic/signed_extensions/asset_hub.dart';
+import 'package:polkadart/extrinsic/signed_extensions/substrate.dart';
+
+abstract class SignedExtensions {
+  static AssetHubSignedExtensions get assetHubSignedExtensions =>
+      AssetHubSignedExtensions();
+  static SubstrateSignedExtensions get substrateSignedExtensions =>
+      SubstrateSignedExtensions();
+
+  String signedExtension(String extension, Map info);
+  String additionalSignedExtension(String extension, Map info);
+}

--- a/packages/polkadart/lib/extrinsic/signed_extensions/substrate.dart
+++ b/packages/polkadart/lib/extrinsic/signed_extensions/substrate.dart
@@ -1,5 +1,15 @@
-class SubstrateSignedExtensions {
-  static String signedExtension(String extension, Map info) {
+import 'package:polkadart/extrinsic/signed_extensions/signed_extensions_abstract.dart';
+
+class SubstrateSignedExtensions implements SignedExtensions {
+  static final SubstrateSignedExtensions _instance =
+      SubstrateSignedExtensions._internal();
+
+  factory SubstrateSignedExtensions() => _instance;
+
+  SubstrateSignedExtensions._internal();
+
+  @override
+  String signedExtension(String extension, Map info) {
     switch (extension) {
       case 'CheckMortality':
         return info['era'];
@@ -12,7 +22,8 @@ class SubstrateSignedExtensions {
     }
   }
 
-  static String additionalSignedExtension(String extension, Map info) {
+  @override
+  String additionalSignedExtension(String extension, Map info) {
     switch (extension) {
       case 'CheckNonce':
         return info['nonce'];

--- a/packages/polkadart/pubspec.yaml
+++ b/packages/polkadart/pubspec.yaml
@@ -4,6 +4,9 @@ version: 0.3.0
 homepage: https://github.com/leonardocustodio/polkadart/tree/main/packages/polkadart
 repository: https://github.com/leonardocustodio/polkadart
 
+# Adding this line until we publish polkadart_keyring's latest version to pub.dev
+publish_to: 'none' # Remove this line if you wish to publish to pub.dev
+
 environment:
   sdk: ">=3.0.1 <4.0.0"
 
@@ -15,6 +18,8 @@ dependencies:
   polkadart_scale_codec: ^1.1.0 # Apache 2.0
   substrate_metadata: ^1.1.0 # Apache 2.0
   hashlib_codecs: ^2.2.0 # BSD-3-Clause
+  polkadart_keyring:
+    path: ../polkadart_keyring
 
 dev_dependencies:
   lints: ^2.0.0


### PR DESCRIPTION
Note: (Have to add `publish_to: None` until we publish `newest` version of polkadart_keyring.)


Have to provide `SignatureType` to `encode()` method.

Now possible to do:
 ```dart
 final extrinsic = Extrinsic(
    signer: publicKey,
    method: encodedCall,
    signature: hexSignature,
    eraPeriod: 64,
    blockNumber: blockNumber,
    nonce: 0,
    tip: 0,
  ).encode(api.registry, SignatureType.sr25519).sign(keyPair);
```

or 

 ```dart
 final extrinsic = Extrinsic(
    signer: publicKey,
    method: encodedCall,
    signature: hexSignature,
    eraPeriod: 64,
    blockNumber: blockNumber,
    nonce: 0,
    tip: 0,
  ).encodeAndSign(api.registry, SignatureType.sr25519, keyPair);
```