### PR TITLE
fix paying extrinsic with custom asset

### DIFF
--- a/packages/polkadart/lib/extrinsic/extrinsic_payload.dart
+++ b/packages/polkadart/lib/extrinsic/extrinsic_payload.dart
@@ -118,7 +118,7 @@ class Extrinsic {
 
   String maybeAssetIdEncoded(dynamic registry) {
     if (_usesChargeAssetTxPayment(registry)) {
-      return assetId != null ?  '01${assetId!.toRadixString(16)}' : '00';
+      return assetId != null ? '01${assetId!.toRadixString(16)}' : '00';
     } else {
       return '';
     }

--- a/packages/polkadart/lib/extrinsic/extrinsic_payload.dart
+++ b/packages/polkadart/lib/extrinsic/extrinsic_payload.dart
@@ -118,7 +118,7 @@ class Extrinsic {
 
   String maybeAssetIdEncoded(dynamic registry) {
     if (_usesChargeAssetTxPayment(registry)) {
-      return assetId != null ? assetId!.toRadixString(16) : '00';
+      return assetId != null ?  '01${assetId!.toRadixString(16)}' : '00';
     } else {
       return '';
     }

--- a/packages/polkadart/lib/extrinsic/extrinsic_payload.dart
+++ b/packages/polkadart/lib/extrinsic/extrinsic_payload.dart
@@ -118,6 +118,7 @@ class Extrinsic {
 
   String maybeAssetIdEncoded(dynamic registry) {
     if (_usesChargeAssetTxPayment(registry)) {
+      // '00' and '01' refer to rust's Option variants 'None' and 'Some'.
       return assetId != null ? '01${assetId!.toRadixString(16)}' : '00';
     } else {
       return '';

--- a/packages/polkadart/lib/extrinsic/signing_payload.dart
+++ b/packages/polkadart/lib/extrinsic/signing_payload.dart
@@ -97,6 +97,7 @@ class SigningPayload {
 
   String maybeAssetIdEncoded(dynamic registry) {
     if (_usesChargeAssetTxPayment(registry)) {
+      // '00' and '01' refer to rust's Option variants 'None' and 'Some'.
       return assetId != null ? '01${assetId!.toRadixString(16)}' : '00';
     } else {
       return '';

--- a/packages/polkadart/lib/extrinsic/signing_payload.dart
+++ b/packages/polkadart/lib/extrinsic/signing_payload.dart
@@ -97,7 +97,7 @@ class SigningPayload {
 
   String maybeAssetIdEncoded(dynamic registry) {
     if (_usesChargeAssetTxPayment(registry)) {
-      return assetId != null ?  '01${assetId!.toRadixString(16)}' : '00';
+      return assetId != null ? '01${assetId!.toRadixString(16)}' : '00';
     } else {
       return '';
     }

--- a/packages/polkadart/lib/extrinsic/signing_payload.dart
+++ b/packages/polkadart/lib/extrinsic/signing_payload.dart
@@ -97,7 +97,7 @@ class SigningPayload {
 
   String maybeAssetIdEncoded(dynamic registry) {
     if (_usesChargeAssetTxPayment(registry)) {
-      return assetId != null ? assetId!.toRadixString(16) : '00';
+      return assetId != null ?  '01${assetId!.toRadixString(16)}' : '00';
     } else {
       return '';
     }


### PR DESCRIPTION
My testing for #401 was unfortunately not good enough; it only worked when the `assetId` was null when sending extrinsics. This PR fixes now the non-null case.