### PR TITLE
Custom Signed Extensions Example

### DIFF
--- a/examples/bin/extrinsic_demo.dart
+++ b/examples/bin/extrinsic_demo.dart
@@ -9,6 +9,8 @@ import 'package:polkadart/polkadart.dart'
         SignatureType,
         SigningPayload,
         StateApi;
+import 'package:polkadart_scale_codec/polkadart_scale_codec.dart'
+    as scale_codec;
 import 'package:polkadart_keyring/polkadart_keyring.dart';
 
 import 'package:polkadart_example/generated/polkadot/polkadot.dart';
@@ -21,6 +23,18 @@ Future<void> main(List<String> arguments) async {
   final stateApi = StateApi(provider);
 
   final runtimeVersion = await stateApi.getRuntimeVersion();
+
+  // Get Metadata
+  final runtimeMetadata = await stateApi.getMetadata();
+  // Get Registry
+  final scale_codec.Registry registry =
+      runtimeMetadata.chainInfo.scaleCodec.registry;
+
+  //
+  // Get SignedExtensions mapped with codecs Map<String, Codec<dynamic>>
+  final Map<String, scale_codec.Codec<dynamic>> signedExtensions =
+      registry.getSignedExtensionTypes();
+  print('Signed Extensions Keys: ${signedExtensions.keys.toList()}');
 
   final specVersion = runtimeVersion.specVersion;
 

--- a/examples/pubspec.yaml
+++ b/examples/pubspec.yaml
@@ -27,4 +27,4 @@ dev_dependencies:
 polkadart:
   output_dir: lib/generated
   chains:
-    polkadot: wss://rpc.polkadot.io
+    polkadot: wss://rpc.ibp.network/polkadot

--- a/packages/polkadart/example/multisig_example.dart
+++ b/packages/polkadart/example/multisig_example.dart
@@ -18,7 +18,8 @@ void main() async {
   final keypairR = await keyring.KeyPair.sr25519.fromUri('//keypairR');
   keypairR.ss58Format = 42;
 
-  final provider = Provider.fromUri(Uri.parse('wss://westend-rpc.polkadot.io'));
+  final provider =
+      Provider.fromUri(Uri.parse('wss://rpc-polkadot.luckyfriday.io'));
 
   ///
   /// Create and Fund Multisig

--- a/packages/polkadart/lib/extrinsic/abstract_payload.dart
+++ b/packages/polkadart/lib/extrinsic/abstract_payload.dart
@@ -6,7 +6,7 @@ abstract class Payload {
   final int eraPeriod; // CheckMortality
   final int nonce; // CheckNonce
   final dynamic tip; // ChargeTransactionPayment
-  final int? assetId; // ChargeAssetTxPayment
+  final Map<String, dynamic> customSignedExtensions;
 
   const Payload({
     required this.method,
@@ -14,10 +14,10 @@ abstract class Payload {
     required this.eraPeriod,
     required this.nonce,
     required this.tip,
-    this.assetId,
+    this.customSignedExtensions = const <String, dynamic>{},
   });
 
-  toEncodedMap(dynamic registry);
+  Map<String, dynamic> toEncodedMap(dynamic registry);
 
   bool usesChargeAssetTxPayment(dynamic registry) {
     if (registry.getSignedExtensionTypes() is Map) {
@@ -31,7 +31,9 @@ abstract class Payload {
   String maybeAssetIdEncoded(dynamic registry) {
     if (usesChargeAssetTxPayment(registry)) {
       // '00' and '01' refer to rust's Option variants 'None' and 'Some'.
-      return assetId != null ? '01${assetId!.toRadixString(16)}' : '00';
+      return customSignedExtensions.containsKey('assetId')
+          ? '01${customSignedExtensions['assetId'].toRadixString(16)}'
+          : '00';
     } else {
       return '';
     }

--- a/packages/polkadart/lib/extrinsic/extrinsic_payload.dart
+++ b/packages/polkadart/lib/extrinsic/extrinsic_payload.dart
@@ -93,7 +93,8 @@ class ExtrinsicPayload extends Payload {
           .keys
           .toList();
     } else {
-      keys = registry.getSignedExtensionTypes() as List<String>;
+      keys =
+          (registry.getSignedExtensionTypes() as List<dynamic>).cast<String>();
     }
 
     for (final signedExtensiontype in keys) {

--- a/packages/polkadart/lib/extrinsic/extrinsic_payload.dart
+++ b/packages/polkadart/lib/extrinsic/extrinsic_payload.dart
@@ -13,6 +13,10 @@ class ExtrinsicPayload extends Payload {
   final Uint8List signer;
   final Uint8List signature;
 
+  ///
+  /// Create a new instance of [ExtrinsicPayload]
+  ///
+  /// For adding assetId or other custom signedExtensions to the payload, use [customSignedExtensions] with key 'assetId' with its mapped value.
   const ExtrinsicPayload({
     required this.signer,
     required super.method,
@@ -21,11 +25,11 @@ class ExtrinsicPayload extends Payload {
     required super.blockNumber,
     required super.nonce,
     required super.tip,
-    super.assetId,
+    super.customSignedExtensions,
   });
 
   @override
-  toEncodedMap(dynamic registry) {
+  Map<String, dynamic> toEncodedMap(dynamic registry) {
     return {
       'signer': signer,
       'method': method,
@@ -51,7 +55,7 @@ class ExtrinsicPayload extends Payload {
       blockNumber: payload.blockNumber,
       nonce: payload.nonce,
       tip: payload.tip,
-      assetId: payload.assetId,
+      customSignedExtensions: payload.customSignedExtensions,
     );
   }
 
@@ -87,22 +91,47 @@ class ExtrinsicPayload extends Payload {
     } else {
       signedExtensions = SignedExtensions.substrateSignedExtensions;
     }
+
     late List<String> keys;
-    if (registry.getSignedExtensionTypes() is Map) {
-      keys = (registry.getSignedExtensionTypes() as Map<String, Codec<dynamic>>)
-          .keys
-          .toList();
-    } else {
-      keys =
-          (registry.getSignedExtensionTypes() as List<dynamic>).cast<String>();
+    {
+      //
+      //
+      // Prepare keys for the encoding
+      if (registry.getSignedExtensionTypes() is Map) {
+        keys =
+            (registry.getSignedExtensionTypes() as Map<String, Codec<dynamic>>)
+                .keys
+                .toList();
+      } else {
+        keys = (registry.getSignedExtensionTypes() as List<dynamic>)
+            .cast<String>();
+      }
     }
 
-    for (final signedExtensiontype in keys) {
-      final payload =
-          signedExtensions.signedExtension(signedExtensiontype, encodedMap);
+    for (final extension in keys) {
+      if (encodedMap.containsKey(extension)) {
+        final payload = signedExtensions.signedExtension(extension, encodedMap);
 
-      if (payload.isNotEmpty) {
-        output.write(hex.decode(payload));
+        if (payload.isNotEmpty) {
+          output.write(hex.decode(payload));
+        }
+      } else {
+        // Most probably, it is a custom signed extension.
+        final signedExtensionMap = registry.getSignedExtensionTypes();
+
+        // check if this signed extension is NullCodec or not!
+        if (signedExtensionMap[extension] != null &&
+            signedExtensionMap[extension] is! NullCodec &&
+            signedExtensionMap[extension].hashCode !=
+                NullCodec.codec.hashCode) {
+          if (customSignedExtensions.containsKey(extension) == false) {
+            // throw exception as this is encodable key and we need this key to be present in customSignedExtensions
+            throw Exception(
+                'Key `$extension` is missing in customSignedExtensions.');
+          }
+          signedExtensionMap[extension]
+              .encodeTo(customSignedExtensions[extension], output);
+        }
       }
     }
 
@@ -122,15 +151,5 @@ class ExtrinsicPayload extends Payload {
   Uint8List encodeAndSign(
       dynamic registry, SignatureType signatureType, keyring.KeyPair keyPair) {
     return keyPair.sign(encode(registry, signatureType));
-  }
-
-  @override
-  String maybeAssetIdEncoded(dynamic registry) {
-    if (usesChargeAssetTxPayment(registry)) {
-      // '00' and '01' refer to rust's Option variants 'None' and 'Some'.
-      return assetId != null ? '01${assetId!.toRadixString(16)}' : '00';
-    } else {
-      return '';
-    }
   }
 }

--- a/packages/polkadart/lib/extrinsic/extrinsic_payload.dart
+++ b/packages/polkadart/lib/extrinsic/extrinsic_payload.dart
@@ -116,6 +116,10 @@ class ExtrinsicPayload extends Payload {
           output.write(hex.decode(payload));
         }
       } else {
+        if (registry.getSignedExtensionTypes() is List) {
+          // This method call is from polkadot cli and not from the Reigstry of the polkadart_scale_codec.
+          continue;
+        }
         // Most probably, it is a custom signed extension.
         final signedExtensionMap = registry.getSignedExtensionTypes();
 

--- a/packages/polkadart/lib/extrinsic/signing_payload.dart
+++ b/packages/polkadart/lib/extrinsic/signing_payload.dart
@@ -97,6 +97,10 @@ class SigningPayload extends Payload {
           tempOutput.write(hex.decode(payload));
         }
       } else {
+        if (registry.getSignedExtensionTypes() is List) {
+          // This method call is from polkadot cli and not from the Reigstry of the polkadart_scale_codec.
+          continue;
+        }
         // Most probably, it is a custom signed extension.
         // check if this signed extension is NullCodec or not!
         final signedExtensionMap = registry.getSignedExtensionTypes();
@@ -147,6 +151,10 @@ class SigningPayload extends Payload {
       } else {
         // Most probably, it is a custom signed extension.
         // check if this signed extension is NullCodec or not!
+        if (registry.getSignedExtensionTypes() is List) {
+          // This method call is from polkadot cli and not from the Reigstry of the polkadart_scale_codec.
+          continue;
+        }
         final additionalSignedExtensionMap =
             registry.getAdditionalSignedExtensionTypes();
         if (additionalSignedExtensionMap[extension] != null &&

--- a/packages/polkadart/lib/extrinsic/signing_payload.dart
+++ b/packages/polkadart/lib/extrinsic/signing_payload.dart
@@ -72,7 +72,8 @@ class SigningPayload extends Payload {
               .toList();
     } else {
       // Usage here for the generated lib from the polkadart_cli
-      typeKeys = registry.getSignedExtensionTypes() as List<String>;
+      typeKeys =
+          (registry.getSignedExtensionTypes() as List<dynamic>).cast<String>();
     }
 
     for (final extension in typeKeys) {
@@ -91,7 +92,8 @@ class SigningPayload extends Payload {
               .toList();
     } else {
       // Usage here for the generated lib from the polkadart_cli
-      extraKeys = registry.getSignedExtensionExtra() as List<String>;
+      extraKeys =
+          (registry.getSignedExtensionExtra() as List<dynamic>).cast<String>();
     }
 
     for (final extension in extraKeys) {

--- a/packages/polkadart/lib/multisig/multisig.dart
+++ b/packages/polkadart/lib/multisig/multisig.dart
@@ -11,7 +11,6 @@ class Multisig {
     required Provider provider,
     required List<String> otherSignatoriesAddressList,
     int tip = 0,
-    int assetId = 0,
     int eraPeriod = 64,
   }) async {
     final meta = await MultiSigMeta.fromProvider(provider: provider);
@@ -32,7 +31,6 @@ class Multisig {
           amount,
         ),
         tip: tip,
-        assetId: assetId,
         eraPeriod: eraPeriod,
         signer: depositorKeyPair,
         provider: provider,
@@ -93,7 +91,6 @@ class Multisig {
     required KeyPair signer,
     required Provider provider,
     required int tip,
-    required int assetId,
     required int eraPeriod,
   }) async {
     final nonce = await SystemApi(provider).accountNextIndex(signer.address);
@@ -102,7 +99,6 @@ class Multisig {
     /// Creating the first approveAsMulti from the account creator.
     final unsignedApprovalPayload = SigningPayload(
       method: method,
-      assetId: assetId,
       blockHash: hex.encode(meta.blockHash),
       blockNumber: meta.blockNumber,
       eraPeriod: eraPeriod,
@@ -147,7 +143,6 @@ class Multisig {
     required KeyPair signer,
     Duration storageKeyDelay = const Duration(seconds: 20),
     int tip = 0,
-    int assetId = 0,
     int eraPeriod = 64,
   }) async {
     final MultisigStorage? multisigStorage = await fetchMultisigStorage(
@@ -184,7 +179,6 @@ class Multisig {
         multiSigStorage: multisigStorage,
       ),
       tip: tip,
-      assetId: assetId,
       eraPeriod: eraPeriod,
       signer: signer,
       provider: provider,
@@ -202,7 +196,6 @@ class Multisig {
     required KeyPair signer,
     Duration storageKeyDelay = const Duration(seconds: 20),
     int tip = 0,
-    int assetId = 0,
     int eraPeriod = 64,
   }) async {
     final MultisigStorage? multisigStorage = await fetchMultisigStorage(
@@ -250,7 +243,6 @@ class Multisig {
         multiSigStorage: multisigStorage,
       ),
       tip: tip,
-      assetId: assetId,
       eraPeriod: eraPeriod,
       signer: signer,
       provider: provider,
@@ -268,7 +260,6 @@ class Multisig {
     required KeyPair signer,
     Duration storageKeyDelay = const Duration(seconds: 25),
     int tip = 0,
-    int assetId = 0,
     int eraPeriod = 64,
   }) async {
     final MultisigStorage? multisigStorage = await fetchMultisigStorage(
@@ -310,7 +301,6 @@ class Multisig {
       ),
       signer: signer,
       tip: tip,
-      assetId: assetId,
       eraPeriod: eraPeriod,
       provider: provider,
     );

--- a/packages/polkadart_scale_codec/lib/core/registry.dart
+++ b/packages/polkadart_scale_codec/lib/core/registry.dart
@@ -8,6 +8,7 @@ class Registry {
   final Map<String, ProxyLoader> _proxyLoaders = <String, ProxyLoader>{};
   final Map<String, ProxyCodec> _proxies = <String, ProxyCodec>{};
   final Map<String, Codec> signedExtensions = <String, Codec>{};
+  final Map<String, Codec> additionalSignedExtensions = <String, Codec>{};
   late int extrinsicVersion;
 
   Registry();
@@ -20,6 +21,12 @@ class Registry {
   /// Get Signed Extensions
   Map<String, Codec> getSignedExtensionTypes() {
     return signedExtensions;
+  }
+
+  ///
+  /// Get Additional Signed Extensions
+  Map<String, Codec> getAdditionalSignedExtensionTypes() {
+    return additonalSignedExtensions;
   }
 
   ProxyCodec _createProxy(

--- a/packages/polkadart_scale_codec/lib/core/registry.dart
+++ b/packages/polkadart_scale_codec/lib/core/registry.dart
@@ -26,7 +26,7 @@ class Registry {
   ///
   /// Get Additional Signed Extensions
   Map<String, Codec> getAdditionalSignedExtensionTypes() {
-    return additonalSignedExtensions;
+    return additionalSignedExtensions;
   }
 
   ProxyCodec _createProxy(


### PR DESCRIPTION
## **User description**
Solves: #359 
- Added example for Custom Signed Extensions.
- With Custom Signed Extensions have the Codecs mapped to it.


___

## **Type**
enhancement


___

## **Description**
- Added an example demonstrating the retrieval of signed extensions from runtime metadata in `extrinsic_demo.dart`.
- Fixed type casting issues in `extrinsic_payload.dart` and `signing_payload.dart` to ensure dynamic types are correctly cast to String.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>extrinsic_demo.dart</strong><dd><code>Add Signed Extensions Retrieval in Extrinsic Demo</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/bin/extrinsic_demo.dart
<li>Imported <code>polkadart_scale_codec</code> as <code>scale_codec</code>.<br> <li> Added code to retrieve and print signed extensions keys from the <br>runtime metadata.<br>


</details>
    

  </td>
  <td><a href="https://github.com/leonardocustodio/polkadart/pull/421/files#diff-49aa83d51521da0e13e5069d8540d4a39fb08eb4c8378639aa262048bd2957d9">+14/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>extrinsic_payload.dart</strong><dd><code>Fix Type Casting in Extrinsic Payload</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/polkadart/lib/extrinsic/extrinsic_payload.dart
<li>Modified type casting for <code>keys</code> to support dynamic to String casting.<br>


</details>
    

  </td>
  <td><a href="https://github.com/leonardocustodio/polkadart/pull/421/files#diff-2859cf016d711057af57ffcce8d535ed7f5ce89aa999eea4c6bd8f47a1b99fdb">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>signing_payload.dart</strong><dd><code>Adjust Type Casting in Signing Payload</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/polkadart/lib/extrinsic/signing_payload.dart
<li>Adjusted type casting for <code>typeKeys</code> and <code>extraKeys</code> to ensure correct <br>String casting.<br>


</details>
    

  </td>
  <td><a href="https://github.com/leonardocustodio/polkadart/pull/421/files#diff-f979cda33170a494b8fa72b2222bd3b47df2e381109974785a56dd7f86bc023e">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Inline File Walkthrough 💎</strong></summary><hr>

For enhanced user experience, the `describe` tool can add file summaries directly to the "Files changed" tab in the PR page.
This will enable you to quickly understand the changes in each file, while reviewing the code changes (diffs).

To enable inline file summary, set `pr_description.inline_file_summary` in the configuration file, possible values are:
- `'table'`: File changes walkthrough table will be displayed on the top of the "Files changed" tab, in addition to the "Conversation" tab.
- `true`: A collapsable file comment with changes title and a changes summary for each file in the PR.
- `false` (default): File changes walkthrough will be added only to the "Conversation" tab.
<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
