### PR TITLE
Fixed http provider send json rpc failed

### DIFF
--- a/packages/polkadart/lib/provider.dart
+++ b/packages/polkadart/lib/provider.dart
@@ -75,16 +75,20 @@ class HttpProvider extends Provider {
 
   @override
   Future<RpcResponse> send(String method, List<dynamic> params) async {
-    final response = await http.post(url, body: {
-      'id': (++_sequence).toString(),
-      'jsonrpc': '2.0',
-      'method': method,
-      'params': params,
-    });
+    final response = await http.post(url,
+        body: jsonEncode(
+          {
+            'id': (++_sequence).toString(),
+            'jsonrpc': '2.0',
+            'method': method,
+            'params': params,
+          },
+        ),
+        headers: {'Content-Type': 'application/json'});
     final data = jsonDecode(response.body);
 
     return RpcResponse(
-      id: data['id'],
+      id: int.tryParse(data['id'].toString()) ?? -1,
       result: data['result'],
     );
   }


### PR DESCRIPTION
Fixed http provider send json rpc failed and make sure response id is always parse-able