### PR TITLE
Add support for `CheckMetadataHash` extension

### DIFF
--- a/packages/polkadart/lib/extrinsic/extrinsic_payload.dart
+++ b/packages/polkadart/lib/extrinsic/extrinsic_payload.dart
@@ -42,14 +42,14 @@ class ExtrinsicPayload extends Payload {
       'tip': tip is int
           ? encodeHex(CompactCodec.codec.encode(tip))
           : encodeHex(CompactBigIntCodec.codec.encode(tip)),
-       // This is for the `CheckMetadataHash` signed extension.
-       // Signing the metadata hash is not supported now, so
-       // the set the enabled byte to false with `mode: '00'`.
-       'mode': '00',
-       // This is for the `CheckMetadataHash` additional signed extension.
-       // Signing the metadata hash is not supported now, so we
-       // sign the `Option<MetadataHash>::None` by setting it to '00'.
-       'metadataHash': '00',
+      // This is for the `CheckMetadataHash` signed extension.
+      // Signing the metadata hash is not supported now, so
+      // the set the enabled byte to false with `mode: '00'`.
+      'mode': '00',
+      // This is for the `CheckMetadataHash` additional signed extension.
+      // Signing the metadata hash is not supported now, so we
+      // sign the `Option<MetadataHash>::None` by setting it to '00'.
+      'metadataHash': '00',
     };
   }
 

--- a/packages/polkadart/lib/extrinsic/extrinsic_payload.dart
+++ b/packages/polkadart/lib/extrinsic/extrinsic_payload.dart
@@ -42,6 +42,7 @@ class ExtrinsicPayload extends Payload {
       'tip': tip is int
           ? encodeHex(CompactCodec.codec.encode(tip))
           : encodeHex(CompactBigIntCodec.codec.encode(tip)),
+      'metadataHash': '00'
     };
   }
 

--- a/packages/polkadart/lib/extrinsic/extrinsic_payload.dart
+++ b/packages/polkadart/lib/extrinsic/extrinsic_payload.dart
@@ -42,10 +42,14 @@ class ExtrinsicPayload extends Payload {
       'tip': tip is int
           ? encodeHex(CompactCodec.codec.encode(tip))
           : encodeHex(CompactBigIntCodec.codec.encode(tip)),
-      // This is for the `CheckMetadataHash` signed extensions.
-      // signing the metadata hash is not supported now, so
-      // the set the enabled byte false with `mode: '00'`.
-      'mode': '00'
+       // This is for the `CheckMetadataHash` signed extension.
+       // Signing the metadata hash is not supported now, so
+       // the set the enabled byte to false with `mode: '00'`.
+       'mode': '00',
+       // This is for the `CheckMetadataHash` additional signed extension.
+       // Signing the metadata hash is not supported now, so we
+       // sign the `Option<MetadataHash>::None` by setting it to '00'.
+       'metadataHash': '00',
     };
   }
 

--- a/packages/polkadart/lib/extrinsic/extrinsic_payload.dart
+++ b/packages/polkadart/lib/extrinsic/extrinsic_payload.dart
@@ -42,7 +42,10 @@ class ExtrinsicPayload extends Payload {
       'tip': tip is int
           ? encodeHex(CompactCodec.codec.encode(tip))
           : encodeHex(CompactBigIntCodec.codec.encode(tip)),
-      'metadataHash': '00'
+      // This is for the `CheckMetadataHash` signed extensions.
+      // signing the metadata hash is not supported now, so
+      // the set the enabled byte false with `mode: '00'`.
+      'mode': '00'
     };
   }
 

--- a/packages/polkadart/lib/extrinsic/signed_extensions/asset_hub.dart
+++ b/packages/polkadart/lib/extrinsic/signed_extensions/asset_hub.dart
@@ -18,7 +18,7 @@ class AssetHubSignedExtensions implements SignedExtensions {
       /*  case 'ChargeAssetTxPayment':
         return ('${info['tip']}${info['assetId']}', true); */
       case 'CheckMetadataHash':
-        return ('${info['metadataHash']}', true);
+        return ('${info['mode']}', true);
       default:
         return ('', false);
     }

--- a/packages/polkadart/lib/extrinsic/signed_extensions/asset_hub.dart
+++ b/packages/polkadart/lib/extrinsic/signed_extensions/asset_hub.dart
@@ -17,6 +17,8 @@ class AssetHubSignedExtensions implements SignedExtensions {
         return (info['nonce'], true);
       /*  case 'ChargeAssetTxPayment':
         return ('${info['tip']}${info['assetId']}', true); */
+      case 'CheckMetadataHash':
+        return ('${info['metadataHash']}', true);
       default:
         return ('', false);
     }
@@ -33,6 +35,8 @@ class AssetHubSignedExtensions implements SignedExtensions {
         return (info['transactionVersion'], true);
       case 'CheckGenesis':
         return (info['genesisHash'], true);
+      case 'CheckMetadataHash':
+        return (info['metadataHash'], true);
       default:
         return ('', false);
     }

--- a/packages/polkadart/lib/extrinsic/signed_extensions/substrate.dart
+++ b/packages/polkadart/lib/extrinsic/signed_extensions/substrate.dart
@@ -18,7 +18,7 @@ class SubstrateSignedExtensions implements SignedExtensions {
       case 'ChargeTransactionPayment':
         return (info['tip'], true);
       case 'CheckMetadataHash':
-        return (info['metadataHash'], true);
+        return (info['mode'], true);
       default:
         return ('', false);
     }

--- a/packages/polkadart/lib/extrinsic/signed_extensions/substrate.dart
+++ b/packages/polkadart/lib/extrinsic/signed_extensions/substrate.dart
@@ -17,6 +17,8 @@ class SubstrateSignedExtensions implements SignedExtensions {
         return (info['nonce'], true);
       case 'ChargeTransactionPayment':
         return (info['tip'], true);
+      case 'CheckMetadataHash':
+        return (info['metadataHash'], true);
       default:
         return ('', false);
     }
@@ -33,6 +35,8 @@ class SubstrateSignedExtensions implements SignedExtensions {
         return (info['transactionVersion'], true);
       case 'CheckGenesis':
         return (info['genesisHash'], true);
+      case 'CheckMetadataHash':
+        return (info['metadataHash'], true);
       default:
         return ('', false);
     }

--- a/packages/polkadart/lib/extrinsic/signing_payload.dart
+++ b/packages/polkadart/lib/extrinsic/signing_payload.dart
@@ -48,6 +48,9 @@ class SigningPayload extends Payload {
       'tip': tip is int
           ? encodeHex(CompactCodec.codec.encode(tip))
           : encodeHex(CompactBigIntCodec.codec.encode(tip)),
+      // This is for the `CheckMetadataHash` signed extensions.
+      // signing the metadata hash is not supported now, so we
+      // sign the `Option<MetadataHash>::None` by setting it to '00'.
       'metadataHash': '00' // assume 0 for now
     };
   }

--- a/packages/polkadart/lib/extrinsic/signing_payload.dart
+++ b/packages/polkadart/lib/extrinsic/signing_payload.dart
@@ -48,6 +48,7 @@ class SigningPayload extends Payload {
       'tip': tip is int
           ? encodeHex(CompactCodec.codec.encode(tip))
           : encodeHex(CompactBigIntCodec.codec.encode(tip)),
+      'metadataHash': '00' // assume 0 for now
     };
   }
 

--- a/packages/polkadart/lib/extrinsic/signing_payload.dart
+++ b/packages/polkadart/lib/extrinsic/signing_payload.dart
@@ -48,10 +48,14 @@ class SigningPayload extends Payload {
       'tip': tip is int
           ? encodeHex(CompactCodec.codec.encode(tip))
           : encodeHex(CompactBigIntCodec.codec.encode(tip)),
-      // This is for the `CheckMetadataHash` signed extensions.
-      // signing the metadata hash is not supported now, so we
+      // This is for the `CheckMetadataHash` signed extension.
+      // signing the metadata hash is not supported now, so
+      // the set the enabled byte false with `mode: '00'`.
+      'mode': '00',
+      // This is for the `CheckMetadataHash` additional signed extensions.
+      // Signing the metadata hash is not supported now, so we
       // sign the `Option<MetadataHash>::None` by setting it to '00'.
-      'metadataHash': '00' // assume 0 for now
+      'metadataHash': '00',
     };
   }
 
@@ -98,6 +102,7 @@ class SigningPayload extends Payload {
     //
     // Traverse through the signedExtension keys and encode the payload
     for (final extension in signedExtensionKeys) {
+      print("Extension $extension");
       final (payload, found) =
           signedExtensions.signedExtension(extension, encodedMap);
       if (found) {

--- a/packages/polkadart/lib/extrinsic/signing_payload.dart
+++ b/packages/polkadart/lib/extrinsic/signing_payload.dart
@@ -102,7 +102,6 @@ class SigningPayload extends Payload {
     //
     // Traverse through the signedExtension keys and encode the payload
     for (final extension in signedExtensionKeys) {
-      print("Extension $extension");
       final (payload, found) =
           signedExtensions.signedExtension(extension, encodedMap);
       if (found) {


### PR DESCRIPTION
This doesn't implement the full feature of the signed extensions. However, signing the actual metadata hash is only valuable for offline clients.

This change makes the api at least compatible with the fellows/runtimes version v1.2.5, i.e. the current versions of Kusama/Westend, and it will also ensure that it works for Polkadot/Paseo after the next runtime upgrade.