### PR TITLE
Add missing error value parse for http provider

### DIFF
--- a/packages/polkadart/lib/provider.dart
+++ b/packages/polkadart/lib/provider.dart
@@ -75,16 +75,20 @@ class HttpProvider extends Provider {
 
   @override
   Future<RpcResponse> send(String method, List<dynamic> params) async {
-    final response = await http.post(url, body: {
-      'id': (++_sequence).toString(),
-      'jsonrpc': '2.0',
-      'method': method,
-      'params': params,
-    });
+    final response = await http.post(url,
+        body: jsonEncode(
+          {
+            'id': (++_sequence).toString(),
+            'jsonrpc': '2.0',
+            'method': method,
+            'params': params,
+          },
+        ),
+        headers: {'Content-Type': 'application/json'});
     final data = jsonDecode(response.body);
 
     return RpcResponse(
-      id: data['id'],
+      id: int.tryParse(data['id'].toString()) ?? -1,
       result: data['result'],
     );
   }

--- a/packages/polkadart/lib/provider.dart
+++ b/packages/polkadart/lib/provider.dart
@@ -90,6 +90,7 @@ class HttpProvider extends Provider {
     return RpcResponse(
       id: int.tryParse(data['id'].toString()) ?? -1,
       result: data['result'],
+      error: data['error'],
     );
   }
 


### PR DESCRIPTION
When send a rpc from http provider if there is an error, should set error value to RpcResponse, or else there is no way to get exception message by user.