### PR TITLE
Bump substrate_metadata

### DIFF
--- a/packages/substrate_metadata/CHANGELOG.md
+++ b/packages/substrate_metadata/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.2.2
+- Fixes `toJson()` when decoding BitArray`s
+
 ## 1.2.1
 - Fixes `UnmodifiableUint8ListView` missing on newer dart versions
 

--- a/packages/substrate_metadata/pubspec.yaml
+++ b/packages/substrate_metadata/pubspec.yaml
@@ -1,6 +1,6 @@
 name: substrate_metadata
 description: Metadata types for Substrate runtimes
-version: 1.2.1
+version: 1.2.2
 homepage: https://github.com/rankanizer/polkadart/tree/main/packages/substrate_metadata
 repository: https://github.com/rankanizer/polkadart
 


### PR DESCRIPTION
### **PR Type**
enhancement, other


___

### **Description**
- Bumped the version of the `substrate_metadata` package from 1.2.1 to 1.2.2.
- This change likely includes enhancements or minor updates that do not break backward compatibility.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pubspec.yaml</strong><dd><code>Bump version of substrate_metadata package to 1.2.2</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/substrate_metadata/pubspec.yaml

- Updated the version from 1.2.1 to 1.2.2.



</details>


  </td>
  <td><a href="https://github.com/leonardocustodio/polkadart/pull/483/files#diff-05c1ffd9bcb44071c7dea88cafeb08e9bbb9abe96b8d1ecec45f31d4df528d36">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

