### PR TITLE
Update http and switch to json_schema

### DIFF
--- a/packages/polkadart/pubspec.yaml
+++ b/packages/polkadart/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   convert: ^3.1.1 # BSD-3-Clause
-  http: ^1.1.0 # BSD-3-Clause
+  http: ^1.2.2 # BSD-3-Clause
   pointycastle: ^3.6.2 # MIT
   web_socket_channel: ^2.3.0 # BSD-3-Clause
   polkadart_scale_codec: ^1.2.0 # Apache 2.0

--- a/packages/polkadart_cli/pubspec.yaml
+++ b/packages/polkadart_cli/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   code_builder: ^4.8.0 # BSD-3-Clause
   convert: ^3.1.1 # BSD-3-Clause
   dart_style: ^2.2.4 # BSD-3-Clause
-  http: ^1.1.0 # BSD-3-Clause
+  http: ^1.2.2 # BSD-3-Clause
   recase: ^4.1.0 # BSD-2-Clause
   path: ^1.8.3 # BSD-3-Clause
   yaml: ^3.1.1 # MIT

--- a/packages/substrate_metadata/lib/utils/spec_version_maker.dart
+++ b/packages/substrate_metadata/lib/utils/spec_version_maker.dart
@@ -1,19 +1,20 @@
 part of utils;
 
 bool validateSpecVersion(dynamic data, {bool reportMultipleErrors = false}) {
-  final schema = JsonSchema.createSchema(SPEC_VERSION_SCHEMA);
-  return schema.validate(data, reportMultipleErrors: reportMultipleErrors);
+  final schema = JsonSchema.create(SPEC_VERSION_SCHEMA);
+  return Validator(schema).validate(data, reportMultipleErrors: reportMultipleErrors).isValid;
 }
 
 bool validateSpecVersionArray(dynamic data,
     {bool reportMultipleErrors = false}) {
-  final schema = JsonSchema.createSchema(
+  final schema = JsonSchema.create(
     <String, dynamic>{
       'type': 'array',
       'items': SPEC_VERSION_SCHEMA,
     },
   );
-  return schema.validate(data, reportMultipleErrors: reportMultipleErrors);
+
+  return Validator(schema).validate(data, reportMultipleErrors: reportMultipleErrors).isValid;
 }
 
 List<SpecVersion> readSpecVersionsFromFilePath(String filePath) {

--- a/packages/substrate_metadata/lib/utils/spec_version_maker.dart
+++ b/packages/substrate_metadata/lib/utils/spec_version_maker.dart
@@ -2,7 +2,9 @@ part of utils;
 
 bool validateSpecVersion(dynamic data, {bool reportMultipleErrors = false}) {
   final schema = JsonSchema.create(SPEC_VERSION_SCHEMA);
-  return Validator(schema).validate(data, reportMultipleErrors: reportMultipleErrors).isValid;
+  return Validator(schema)
+      .validate(data, reportMultipleErrors: reportMultipleErrors)
+      .isValid;
 }
 
 bool validateSpecVersionArray(dynamic data,
@@ -13,8 +15,9 @@ bool validateSpecVersionArray(dynamic data,
       'items': SPEC_VERSION_SCHEMA,
     },
   );
-
-  return Validator(schema).validate(data, reportMultipleErrors: reportMultipleErrors).isValid;
+  return Validator(schema)
+      .validate(data, reportMultipleErrors: reportMultipleErrors)
+      .isValid;
 }
 
 List<SpecVersion> readSpecVersionsFromFilePath(String filePath) {

--- a/packages/substrate_metadata/lib/utils/utils.dart
+++ b/packages/substrate_metadata/lib/utils/utils.dart
@@ -2,7 +2,7 @@ library utils;
 
 import 'dart:convert';
 import 'dart:io';
-import 'package:json_schema2/json_schema2.dart';
+import 'package:json_schema/json_schema.dart';
 import 'package:polkadart_scale_codec/polkadart_scale_codec.dart';
 import '../constants/spec_version_schema.dart';
 import '../exceptions/exceptions.dart';

--- a/packages/substrate_metadata/pubspec.yaml
+++ b/packages/substrate_metadata/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   equatable: ^2.0.5
-  json_schema2: ^2.0.2+9 # MIT
+  json_schema: ^5.2.0 # MIT
   pointycastle: ^3.6.2 # BSD-3-Clause
   polkadart_scale_codec: ^1.2.0
   utility: ^1.0.3

--- a/packages/substrate_metadata/pubspec.yaml
+++ b/packages/substrate_metadata/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   equatable: ^2.0.5
-  json_schema: ^5.2.0 # MIT
+  json_schema: ^5.2.0
   pointycastle: ^3.6.2 # BSD-3-Clause
   polkadart_scale_codec: ^1.2.0
   utility: ^1.0.3


### PR DESCRIPTION
[json_schema2](https://pub.dev/packages/json_schema2) is discontinued. It's recommended to replace with [json_schema](https://pub.dev/packages/json_schema).