### PR TITLE
Disable multisig analysis

### DIFF
--- a/packages/polkadart/analysis_options.yaml
+++ b/packages/polkadart/analysis_options.yaml
@@ -1,5 +1,9 @@
 include: package:lints/recommended.yaml
 
+analyzer:
+  exclude:
+    - lib/multisig/*
+
 linter:
   rules:
     constant_identifier_names: false


### PR DESCRIPTION
We are disabling the multisig analysis for now, until the substrate_metadata changes are finalized so we can check other PRs that are coming through.