### PR TITLE
docs: Update ink_abi and ink_cli documentation with examples.

### DIFF
--- a/docs/src/content/docs/guides/contracts-interaction.mdx
+++ b/docs/src/content/docs/guides/contracts-interaction.mdx
@@ -1,0 +1,108 @@
+---
+title: Interacting with ink! Smart Contracts
+sidebar:
+  order: 6
+---
+
+This guide shows how to interact with ink! smart contracts using Polkadart. We'll demonstrate using the Flipper contract example.
+
+### Prerequisites
+
+Before getting started, you'll need to:
+
+1. [Set up your ink! development environment](https://use.ink/getting-started/setup) - Install Rust and required dependencies
+2. [Create an ink! project](https://use.ink/getting-started/creating-an-ink-project) - Create and test a basic Flipper contract
+3. [Build your contract](https://use.ink/getting-started/building-your-contract) - Compile the contract to Wasm
+4. [Run a Substrate node](https://use.ink/getting-started/running-substrate) - Start a local development node
+
+For more details, refer to the [official ink! documentation](https://use.ink/).
+
+#### Installation
+
+Add the required dependencies to your `pubspec.yaml`:
+
+```yaml
+dependencies:
+  ink_abi: any
+  ink_cli: any
+  polkadart: any
+  polkadart_keyring: any
+```
+
+Run:
+```bash
+dart pub get
+```
+
+#### Generate Contract Bindings
+
+Create a file named `generate_contract.dart`:
+
+```dart
+import 'package:ink_cli/ink_cli.dart';
+
+void main() {
+  final fileOutput = FileOutput('generated_flipper.dart');
+  final generator =
+      TypeGenerator(abiFilePath: 'flipper.json', fileOutput: fileOutput);
+  generator.generate();
+  fileOutput.write();
+}
+```
+
+Run this script to generate the contract bindings:
+
+```bash
+dart run generate_contract.dart
+```
+
+#### Deploy and Interact
+
+Create a file named `flipper_demo.dart`:
+
+```dart
+import 'dart:io';
+import 'dart:typed_data';
+import 'package:polkadart/polkadart.dart';
+import 'package:polkadart_keyring/polkadart_keyring.dart';
+import 'generated_flipper.dart';
+
+Future<void> main() async {
+  final provider = Provider.fromUri(Uri.parse('ws://127.0.0.1:9944'));
+  final alice = await KeyPair.sr25519.fromUri('//Alice');
+
+  // Deploy contract
+  final contract = Contract(
+    provider: provider,
+    address: Uint8List.fromList(alice.publicKey.bytes),
+  );
+
+  final result = await contract.new_contract(
+    init_value: true,
+    code: await File('flipper.wasm').readAsBytes(),
+    keyPair: alice,
+  );
+
+  final contractAddress = result.contractAddress;
+  print('Contract deployed at: $contractAddress');
+
+  // Initialize contract instance
+  final deployedContract = Contract(
+    provider: provider,
+    address: Uint8List.fromList(result.contractAddress),
+  );
+
+  await Future.delayed(Duration(seconds: 1));
+
+  // Query initial value
+  final initialValue = await deployedContract.get();
+  print('Initial value: $initialValue');
+
+  // Flip value
+  await deployedContract.flip();
+
+  // Query new value
+  final newValue = await deployedContract.get();
+  print('New value: $newValue');
+}
+```

--- a/docs/src/content/docs/guides/contracts-interaction.mdx
+++ b/docs/src/content/docs/guides/contracts-interaction.mdx
@@ -97,12 +97,5 @@ Future<void> main() async {
   // Query initial value
   final initialValue = await deployedContract.get();
   print('Initial value: $initialValue');
-
-  // Flip value
-  await deployedContract.flip();
-
-  // Query new value
-  final newValue = await deployedContract.get();
-  print('New value: $newValue');
 }
 ```

--- a/docs/src/content/docs/ink/ink_abi.mdx
+++ b/docs/src/content/docs/ink/ink_abi.mdx
@@ -46,11 +46,8 @@ import 'dart:io';
 import 'package:ink_abi/ink_abi_base.dart';
 
 void main() {
-  // Define the path to the Flipper metadata JSON file
-  final String jsonFilePath = './example/flipper.json';
-
   // Read and parse the Flipper contract metadata
-  final json = jsonDecode(File(jsonFilePath).readAsStringSync());
+  final json = jsonDecode(File('flipper.json').readAsStringSync());
 
   // Initialize InkAbi with Flipper metadata
   final InkAbi inkAbi = InkAbi(json);

--- a/docs/src/content/docs/ink/ink_abi.mdx
+++ b/docs/src/content/docs/ink/ink_abi.mdx
@@ -38,7 +38,7 @@ Currently, `ink_abi` supports metadata versions: **v3, v4, v5**.
 
 ## Example Usage
 
-Below is an example demonstrating how to load and parse an ink! contract metadata file:
+Below is an example demonstrating how to load and parse the metadata for a Flipper smart contract:
 
 ```dart
 import 'dart:convert';
@@ -46,16 +46,15 @@ import 'dart:io';
 import 'package:ink_abi/ink_abi_base.dart';
 
 void main() {
-  // Define the path to the metadata JSON file
-  final String dir = Directory.current.absolute.path;
-  final String jsonFilePath = '$dir/your_metadata_json_file.json';
+  // Define the path to the Flipper metadata JSON file
+  final String jsonFilePath = './example/flipper.json';
 
-  // Read and parse JSON metadata
+  // Read and parse the Flipper contract metadata
   final json = jsonDecode(File(jsonFilePath).readAsStringSync());
-  
-  // Initialize InkAbi with parsed metadata
+
+  // Initialize InkAbi with Flipper metadata
   final InkAbi inkAbi = InkAbi(json);
 }
 ```
 
-This initializes an `InkAbi` instance using metadata from a JSON file, allowing interaction with the contract in a structured manner.
+This initializes an `InkAbi` instance using metadata from the Flipper contract JSON file, allowing interaction with the Flipper contract's flip and get methods in a structured manner.

--- a/docs/src/content/docs/ink/ink_cli.mdx
+++ b/docs/src/content/docs/ink/ink_cli.mdx
@@ -18,10 +18,10 @@ Add the following dependencies to your `pubspec.yaml` file:
 
 ```yaml
 dependencies:
+  ink_abi: any
   ink_cli: any
   polkadart: any
   polkadart_keyring: any
-  ink_abi: any
 ```
 
 Then, run:

--- a/docs/src/content/docs/ink/ink_cli.mdx
+++ b/docs/src/content/docs/ink/ink_cli.mdx
@@ -44,10 +44,9 @@ import 'dart:io';
 import 'package:ink_cli/ink_cli.dart';
 
 void generateTypes() {
-  final String dir = Directory.current.absolute.path;
-  final fileOutput = FileOutput('$dir/example/generated_flipper.dart');
+  final fileOutput = FileOutput('generated_flipper.dart');
   final generator = TypeGenerator(
-      abiFilePath: './example/flipper.json', fileOutput: fileOutput);
+      abiFilePath: 'flipper.json', fileOutput: fileOutput);
   generator.generate();
   fileOutput.write();
 }
@@ -64,7 +63,7 @@ import 'dart:typed_data';
 import 'package:ink_cli/ink_cli.dart';
 import 'package:polkadart/polkadart.dart';
 import 'package:polkadart_keyring/polkadart_keyring.dart';
-import '../example/generated_flipper.dart';
+import 'generated_flipper.dart';
 
 Future<InstantiateRequest> deployContract() async {
   final polkadart = Provider.fromUri(Uri.parse('ws://127.0.0.1:9944'));
@@ -75,7 +74,7 @@ Future<InstantiateRequest> deployContract() async {
     address: Uint8List.fromList(alice.publicKey.bytes.toList()),
   );
 
-  final contractFile = File('./example/flipper.wasm');
+  final contractFile = File('flipper.wasm');
 
   final InstantiateRequest result = await contract.new_contract(
     init_value: true,
@@ -96,7 +95,7 @@ Here's an example of interacting with a deployed contract:
 ```dart
 import 'dart:typed_data';
 import 'package:polkadart/polkadart.dart';
-import '../example/generated_flipper.dart';
+import 'generated_flipper.dart';
 
 void callContract(List<int> address) async {
   final polkadart = Provider.fromUri(Uri.parse('ws://127.0.0.1:9944'));

--- a/docs/src/content/docs/ink/ink_cli.mdx
+++ b/docs/src/content/docs/ink/ink_cli.mdx
@@ -106,11 +106,8 @@ void callContract(List<int> address) async {
     address: Uint8List.fromList(address),
   );
 
-  print('Flip value: ${await contract.get()}');
-
-  await contract.flip();
-
-  print('Flip value after flip: ${await contract.get()}');
+  // Call the get method
+  print('Get value: ${await contract.get()}');
 }
 ```
 

--- a/docs/src/content/docs/ink/ink_cli.mdx
+++ b/docs/src/content/docs/ink/ink_cli.mdx
@@ -2,7 +2,7 @@
 title: Ink CLI
 ---
 
-`ink_cli` is a Dart library designed to simplify the process of generating Dart classes and methods for interacting with ink! smart contracts. The first step is to generate type-safe Dart code from your contract metadata using the TypeGenerator.
+`ink_cli` is a Dart library designed to simplify the process of generating Dart classes and methods for interacting with ink! smart contracts. This documentation will show you how to use ink_cli with examples from a simple Flipper contract.
 
 ## Requirements
 
@@ -35,15 +35,15 @@ or
   flutter pub get
 ```
 
-## Generate Contract Class
+## Generating Contract Classes
 
-The first step to interact with an ink! contract is to generate the Dart contract class from the contract metadata:
+The core functionality of ink_cli is generating type-safe Dart classes from ink! contract metadata. Here's how to generate contract classes:
 
 ```dart
 import 'dart:io';
 import 'package:ink_cli/ink_cli.dart';
 
-void main() {
+void generateTypes() {
   final String dir = Directory.current.absolute.path;
   final fileOutput = FileOutput('$dir/example/generated_flipper.dart');
   final generator = TypeGenerator(
@@ -53,59 +53,70 @@ void main() {
 }
 ```
 
-This will generate a type-safe Dart class with all the contract methods and types that can be imported and used to interact with the deployed contract.
+## Deploying Contracts
 
-## Deploying and Interacting with a Contract
-
-Once the contract class is generated, you can use it to deploy and interact with the smart contract on a Substrate blockchain.
-
-### Example: Deploying the Flipper Contract
+Once classes are generated, you can deploy contracts using the generated code:
 
 ```dart
+import 'dart:io';
+import 'dart:typed_data' show Uint8List;
 import 'dart:typed_data';
+import 'package:ink_cli/ink_cli.dart';
 import 'package:polkadart/polkadart.dart';
 import 'package:polkadart_keyring/polkadart_keyring.dart';
-import 'generated_flipper.dart';
+import '../example/generated_flipper.dart';
 
-void main() async {
+Future<InstantiateRequest> deployContract() async {
   final polkadart = Provider.fromUri(Uri.parse('ws://127.0.0.1:9944'));
-
-  // Using Alice account
-  final alice = KeyPair.sr25519.fromUri('//Alice');
-
-  // Alternative: Using custom seed
-  // final keyPair = KeyPair.sr25519.fromSeed(decodeHex(
-  //     '0xe5be9a5092b81bca64be81d212e7f2f9eba183bb7a90954f7b76361f6edb5c0a'));
+  final alice = await KeyPair.sr25519.fromUri('//Alice');
 
   final contract = Contract(
     provider: polkadart,
     address: Uint8List.fromList(alice.publicKey.bytes.toList()),
   );
 
+  final contractFile = File('./example/flipper.wasm');
+
   final InstantiateRequest result = await contract.new_contract(
     init_value: true,
-    code: decodeHex(Constants.flipperCode),
+    code: await contractFile.readAsBytes(),
     keyPair: alice,
   );
-  print('Contract deployed: $result');
+
+  print('Contract address: 0x${encodeHex(result.contractAddress)}');
+
+  return result;
 }
 ```
 
-### Example: Calling Contract Methods
+## Contract Interaction
 
-After generating code, you can call contract functions to flip the boolean value and get its current state.
+Here's an example of interacting with a deployed contract:
 
 ```dart
-Future<void> flip(Contract contract) async {
-  await contract.flip();
-}
+import 'dart:typed_data';
+import 'package:polkadart/polkadart.dart';
+import '../example/generated_flipper.dart';
 
-Future<bool> get(Contract contract) async {
-  return await contract.get();
+void callContract(List<int> address) async {
+  final polkadart = Provider.fromUri(Uri.parse('ws://127.0.0.1:9944'));
+
+  final contract = Contract(
+    provider: polkadart,
+    address: Uint8List.fromList(address),
+  );
+
+  print('Flip value: ${await contract.get()}');
+
+  await contract.flip();
+
+  print('Flip value after flip: ${await contract.get()}');
 }
 ```
 
-## Why Use ink_cli?
+## Features
+
+ink_cli provides several key features:
 
 - **Automated Code Generation**: No need to manually write contract interaction code.
 - **Seamless Integration**: Works with `polkadart` for blockchain communication.

--- a/docs/src/content/docs/ink/overview.mdx
+++ b/docs/src/content/docs/ink/overview.mdx
@@ -2,60 +2,48 @@
 title: Getting Started with ink! Smart Contracts
 ---
 
-import { CardGrid, LinkCard } from '@astrojs/starlight/components'
+The Polkadart ink! packages provide tools for interacting with ink! smart contracts from Dart and Flutter applications. You can use these packages to parse contract metadata, generate type-safe bindings, deploy contracts and interact with them.
 
-ink! is a Rust-based domain-specific language for writing WebAssembly smart contracts that provides specialized #[ink(...)] attribute macros enabling secure and efficient smart contract development on Substrate-based chains.
+#### Installation
 
-Before proceeding, ensure you have followed the complete setup guide at https://use.ink/getting-started/setup to configure your development environment with all required dependencies including Rust, cargo-contract, and other tools.
+Add the following to your `pubspec.yaml` file:
 
-#### Creating Your First Contract
-
-Create a new ink! contract project:
-
-```bash title="Create new contract"
-cargo contract new flipper
-cd flipper
+```yaml title="pubspec.yaml"
+dependencies:
+  ink_abi: ^0.2.2
+  ink_cli: ^0.2.2
 ```
 
-Build the contract to generate the Wasm bundle:
+Get the dependencies by running:
 
-```bash title="Build contract"
-cargo contract build
+```bash
+dart pub get
 ```
 
-This will generate the following files in `target/ink/`:
-- `.contract` bundle file
-- `.wasm` WebAssembly binary
-- `.json` metadata file
+#### Sample usage
 
-#### Deploying Your Contract
+```dart title="demo.dart"
+import 'dart:convert';
+import 'dart:io';
+import 'package:ink_abi/ink_abi.dart';
+import 'package:ink_cli/ink_cli.dart';
 
-First, start your local node (if you haven't installed it yet, follow the guide at https://use.ink/getting-started/running-substrate):
+Future<void> main() async {
+  // Parse contract metadata
+  final json = jsonDecode(File('flipper.json').readAsStringSync());
+  final abi = InkAbi(json);
 
-```bash title="Start local node"
-substrate-contracts-node
+  // Generate Dart bindings
+  final generator = TypeGenerator(
+    abiFilePath: 'flipper.json',
+    fileOutput: FileOutput('generated_flipper.dart')
+  );
+  generator.generate();
+
+  print('Contract ABI loaded and bindings generated');
+}
 ```
 
-Then the contract can be deployed using the contracts UI:
+This will load the Flipper contract metadata and generate type-safe Dart bindings for interacting with the contract.
 
-```dart title="Deploy steps"
-1. Go to https://ui.use.ink
-2. Select "Local Node" from the dropdown at top left
-3. Click "Add New Contract" in sidebar
-4. Click "Upload New Contract Code"
-5. Select deployment account (e.g. ALICE)
-6. Name your contract (e.g. "Flipper")
-7. Drag & drop the .contract file
-8. Click "Next"
-9. Accept default settings
-10. Click "Upload and Instantiate"
-```
-
-#### Sample Usage
-
-Learn how to interact with ink! smart contracts using Polkadart tools and libraries.
-
-<CardGrid>
-    <LinkCard title="Parse contract metadata" href="/ink/ink_abi" description="Parse and handle ink! contract metadata"></LinkCard>
-    <LinkCard title="Generate contract bindings" href="/ink/ink_cli" description="Generate type-safe Dart code from contract metadata"></LinkCard>
-</CardGrid>
+The ink! packages allow you to work with smart contracts in a type-safe way, making contract interactions more reliable and maintainable.

--- a/docs/src/content/docs/ink/overview.mdx
+++ b/docs/src/content/docs/ink/overview.mdx
@@ -10,8 +10,8 @@ Add the following to your `pubspec.yaml` file:
 
 ```yaml title="pubspec.yaml"
 dependencies:
-  ink_abi: ^0.2.2
-  ink_cli: ^0.2.2
+  ink_abi: any
+  ink_cli: any
 ```
 
 Get the dependencies by running:

--- a/docs/src/content/docs/ink/overview.mdx
+++ b/docs/src/content/docs/ink/overview.mdx
@@ -23,7 +23,10 @@ Build the contract to generate the Wasm bundle:
 cargo contract build
 ```
 
-This will generate the `.contract` bundle file in `target/ink/`.
+This will generate the following files in `target/ink/`:
+- `.contract` bundle file
+- `.wasm` WebAssembly binary
+- `.json` metadata file
 
 #### Deploying Your Contract
 


### PR DESCRIPTION
This pull request includes updates to the documentation to improve clarity and provide more specific examples for interacting with ink! smart contracts using Dart. The changes primarily focus on demonstrating usage with the Flipper contract example and ensuring consistency across various documentation pages.

Documentation improvements:

* [`docs/src/content/docs/guides/contracts-interaction.mdx`](diffhunk://#diff-b510673e61d0a05a04354c2f189e8ff429a0ca0f957b33568b93007f5b4c91b0R1-R108): Added a new guide on interacting with ink! smart contracts using Polkadart, including prerequisites, installation steps, and example scripts for generating contract bindings and deploying/interacting with the Flipper contract.
* [`docs/src/content/docs/ink/ink_abi.mdx`](diffhunk://#diff-b4eaaba65a39ffbf50921eb5894f2d90d4d99d2a5ba923eb9358f9e76b6e87d7L41-R57): Updated the example usage section to specifically reference the Flipper contract, providing clearer context for loading and parsing contract metadata.
* [`docs/src/content/docs/ink/ink_cli.mdx`](diffhunk://#diff-b4241b1679125bd709559ee33b9f3dedc6807638a24da62a1b6a3ec58af1b7e7L5-R5): Revised the documentation to use the Flipper contract as an example, added missing dependencies to `pubspec.yaml`, and provided detailed steps for generating contract classes, deploying contracts, and interacting with them. [[1]](diffhunk://#diff-b4241b1679125bd709559ee33b9f3dedc6807638a24da62a1b6a3ec58af1b7e7L5-R5) [[2]](diffhunk://#diff-b4241b1679125bd709559ee33b9f3dedc6807638a24da62a1b6a3ec58af1b7e7R21-L24) [[3]](diffhunk://#diff-b4241b1679125bd709559ee33b9f3dedc6807638a24da62a1b6a3ec58af1b7e7L38-R115)
* [`docs/src/content/docs/ink/overview.mdx`](diffhunk://#diff-5eb14993d02bd2e676ab16fd23243b7a134681a9b508bccce628a181a43e72f4L5-R49): Updated the overview to include installation instructions and a sample usage section for the ink! packages, demonstrating how to parse contract metadata and generate Dart bindings.