### PR TITLE
Revert: xxh64

### DIFF
--- a/packages/polkadart/lib/substrate/hash/xxh64.dart
+++ b/packages/polkadart/lib/substrate/hash/xxh64.dart
@@ -61,8 +61,7 @@ class XXHash64Sink extends BlockHashSink {
   static int _rotl(int x, int n) => (x << n) | (x >>> (64 - n));
 
   @pragma('vm:prefer-inline')
-  static int _accumulate(int x, int y) =>
-      _rotl((x + y * prime64_2), 31) * prime64_1;
+  static int _accumulate(int x, int y) => _rotl((x + y * prime64_2), 31) * prime64_1;
 
   @override
   void $update([List<int>? block, int offset = 0, bool last = false]) {
@@ -73,8 +72,7 @@ class XXHash64Sink extends BlockHashSink {
   }
 
   @pragma('vm:prefer-inline')
-  static int _merge(int h, int a) =>
-      (h ^ _accumulate(0, a)) * prime64_1 + prime64_4;
+  static int _merge(int h, int a) => (h ^ _accumulate(0, a)) * prime64_1 + prime64_4;
 
   @override
   Uint8List $finalize() {

--- a/packages/polkadart/lib/substrate/hash/xxh64.dart
+++ b/packages/polkadart/lib/substrate/hash/xxh64.dart
@@ -9,26 +9,24 @@ import 'block_hash.dart';
 
 /// This implementation is derived from
 /// https://github.com/easyaspi314/xxhash-clean/blob/master/xxhash64-ref.c
-/// and
-/// https://github.com/polkadot-js/common/blob/20d3af56ec0dd375bf21faa7f3de3b70b847c58b/packages/util-crypto/src/xxhash/xxhash64.ts
-
 class XXHash64Sink extends BlockHashSink {
   final int seed;
 
   @override
   final int hashLength = 8;
 
-  static final _u_64 = BigInt.parse('0xffffffffffffffff');
-  static final prime64_1 = BigInt.parse('0x9E3779B185EBCA87');
-  static final prime64_2 = BigInt.parse('0xC2B2AE3D27D4EB4F');
-  static final prime64_3 = BigInt.parse('0x165667B19E3779F9');
-  static final prime64_4 = BigInt.parse('0x85EBCA77C2B2AE63');
-  static final prime64_5 = BigInt.parse('0x27D4EB2F165667C5');
+  static const int prime64_1 = 0x9E3779B185EBCA87;
+  static const int prime64_2 = 0xC2B2AE3D27D4EB4F;
+  static const int prime64_3 = 0x165667B19E3779F9;
+  static const int prime64_4 = 0x85EBCA77C2B2AE63;
+  static const int prime64_5 = 0x27D4EB2F165667C5;
 
-  late BigInt _acc1;
-  late BigInt _acc2;
-  late BigInt _acc3;
-  late BigInt _acc4;
+  int _acc1 = 0;
+  int _acc2 = 0;
+  int _acc3 = 0;
+  int _acc4 = 0;
+
+  late final Uint64List qbuffer = buffer.buffer.asUint64List();
 
   XXHash64Sink(this.seed) : super(32) {
     reset();
@@ -37,11 +35,10 @@ class XXHash64Sink extends BlockHashSink {
   @override
   void reset() {
     super.reset();
-    final s = BigInt.from(seed);
-    _acc1 = (s + prime64_1 + prime64_2) & _u_64;
-    _acc2 = (s + prime64_2) & _u_64;
-    _acc3 = (s + BigInt.zero) & _u_64;
-    _acc4 = (s - prime64_1) & _u_64;
+    _acc1 = seed + prime64_1 + prime64_2;
+    _acc2 = seed + prime64_2;
+    _acc3 = seed + 0;
+    _acc4 = seed - prime64_1;
   }
 
   @override
@@ -54,115 +51,89 @@ class XXHash64Sink extends BlockHashSink {
       }
       buffer[pos] = chunk[start];
     }
+    if (pos == blockLength) {
+      $update();
+      pos = 0;
+    }
   }
+
+  @pragma('vm:prefer-inline')
+  static int _rotl(int x, int n) => (x << n) | (x >>> (64 - n));
+
+  @pragma('vm:prefer-inline')
+  static int _accumulate(int x, int y) =>
+      _rotl((x + y * prime64_2), 31) * prime64_1;
 
   @override
   void $update([List<int>? block, int offset = 0, bool last = false]) {
-    // Process the 32-byte block (4 * 64 bits)
-    final v1 = _from64(buffer, 0);
-    final v2 = _from64(buffer, 8);
-    final v3 = _from64(buffer, 16);
-    final v4 = _from64(buffer, 24);
-
-    _acc1 = _accumulate(_acc1, v1);
-    _acc2 = _accumulate(_acc2, v2);
-    _acc3 = _accumulate(_acc3, v3);
-    _acc4 = _accumulate(_acc4, v4);
+    _acc1 = _accumulate(_acc1, qbuffer[0]);
+    _acc2 = _accumulate(_acc2, qbuffer[1]);
+    _acc3 = _accumulate(_acc3, qbuffer[2]);
+    _acc4 = _accumulate(_acc4, qbuffer[3]);
   }
+
+  @pragma('vm:prefer-inline')
+  static int _merge(int h, int a) =>
+      (h ^ _accumulate(0, a)) * prime64_1 + prime64_4;
 
   @override
   Uint8List $finalize() {
-    var hash = BigInt.zero;
-    final length = BigInt.from(messageLength);
+    int i, t;
+    int hash;
 
     if (messageLength < 32) {
-      hash = (BigInt.from(seed) + prime64_5) & _u_64;
+      hash = seed + prime64_5;
     } else {
-      hash = (_rotl(_acc1, 1) + _rotl(_acc2, 7) + _rotl(_acc3, 12) + _rotl(_acc4, 18)) & _u_64;
+      // accumulate
+      hash = _rotl(_acc1, 1);
+      hash += _rotl(_acc2, 7);
+      hash += _rotl(_acc3, 12);
+      hash += _rotl(_acc4, 18);
 
+      // merge round
       hash = _merge(hash, _acc1);
       hash = _merge(hash, _acc2);
       hash = _merge(hash, _acc3);
       hash = _merge(hash, _acc4);
     }
 
-    hash = (hash + length) & _u_64;
+    hash += messageLength;
 
-    int t = 0;
-
-    // Process remaining 64 bits
-    while (t + 8 <= pos) {
-      final v = _from64(buffer, t);
-      hash = (hash ^ _accumulate(BigInt.zero, v)) & _u_64;
+    // process the remaining data
+    for (i = t = 0; t + 8 <= pos; ++i, t += 8) {
+      hash ^= _accumulate(0, qbuffer[i]);
       hash = _rotl(hash, 27);
-      hash = ((hash * prime64_1) + prime64_4) & _u_64;
-      t += 8;
+      hash *= prime64_1;
+      hash += prime64_4;
     }
-
-    // Process remaining 32 bits
-    while (t + 4 <= pos) {
-      final v = _from32(buffer, t);
-      hash = (hash ^ ((v * prime64_1) & _u_64)) & _u_64;
+    for (i <<= 1; t + 4 <= pos; ++i, t += 4) {
+      hash ^= sbuffer[i] * prime64_1;
       hash = _rotl(hash, 23);
-      hash = ((hash * prime64_2) + prime64_3) & _u_64;
-      t += 4;
+      hash *= prime64_2;
+      hash += prime64_3;
     }
-
-    // Process remaining bytes
-    while (t < pos) {
-      final v = BigInt.from(buffer[t++]);
-      hash = (hash ^ ((v * prime64_5) & _u_64)) & _u_64;
+    for (; t < pos; t++) {
+      hash ^= buffer[t] * prime64_5;
       hash = _rotl(hash, 11);
-      hash = (hash * prime64_1) & _u_64;
+      hash *= prime64_1;
     }
 
-    hash = (hash ^ (hash >> 33)) & _u_64;
-    hash = (hash * prime64_2) & _u_64;
-    hash = (hash ^ (hash >> 29)) & _u_64;
-    hash = (hash * prime64_3) & _u_64;
-    hash = (hash ^ (hash >> 32)) & _u_64;
+    // avalanche
+    hash ^= hash >>> 33;
+    hash *= prime64_2;
+    hash ^= hash >>> 29;
+    hash *= prime64_3;
+    hash ^= hash >>> 32;
 
-    // Convert to Uint8List (big-endian)
-    final result = Uint8List(8);
-    var h = hash;
-    for (int i = 7; i >= 0; i--) {
-      result[i] = (h & BigInt.from(0xff)).toInt();
-      h = h >> 8;
-    }
-    return result;
-  }
-
-  static BigInt _rotl(BigInt x, int n) {
-    final shiftedLeft = (x << n) & _u_64;
-    final shiftedRight = x >> (64 - n);
-    return (shiftedLeft | shiftedRight) & _u_64;
-  }
-
-  static BigInt _accumulate(BigInt x, BigInt y) {
-    final mul = (y * prime64_2) & _u_64;
-    final add = (x + mul) & _u_64;
-    final rot = _rotl(add, 31);
-    return (rot * prime64_1) & _u_64;
-  }
-
-  static BigInt _merge(BigInt h, BigInt a) {
-    final merged = (h ^ _accumulate(BigInt.zero, a)) & _u_64;
-    return ((merged * prime64_1) + prime64_4) & _u_64;
-  }
-
-  static BigInt _from64(Uint8List u8a, int offset) {
-    BigInt val = BigInt.zero;
-    for (int i = 7; i >= 0; i--) {
-      val = (val << 8) + BigInt.from(u8a[offset + i]);
-    }
-    return val & _u_64;
-  }
-
-  static BigInt _from32(Uint8List u8a, int offset) {
-    BigInt val = BigInt.zero;
-    for (int i = 3; i >= 0; i--) {
-      val = (val << 8) + BigInt.from(u8a[offset + i]);
-    }
-    return val & _u_64;
+    return Uint8List.fromList([
+      hash >>> 56,
+      hash >>> 48,
+      hash >>> 40,
+      hash >>> 32,
+      hash >>> 24,
+      hash >>> 16,
+      hash >>> 8,
+      hash,
+    ]);
   }
 }


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Reimplement xxh64 using 64-bit ints

- Remove BigInt-based operations

- Optimize buffering with Uint64List

- Inline rotations and merges


___

### Diagram Walkthrough


```mermaid
flowchart LR
  BigIntImpl["BigInt-based xxh64"] -- replaced by --> Int64Impl["64-bit int xxh64"]
  Int64Impl -- adds --> Uint64Buffer["Uint64List qbuffer"]
  Int64Impl -- inlines --> Helpers["_rotl/_accumulate/_merge"]
  Finalize["$finalize optimized"] -- uses --> Helpers
  Finalize -- outputs --> Bytes["Uint8List (big-endian)"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>xxh64.dart</strong><dd><code>Port xxh64 to native 64-bit int path</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/polkadart/lib/substrate/hash/xxh64.dart

<ul><li>Switch primes/constants to 64-bit ints<br> <li> Replace BigInt math with int ops and shifts<br> <li> Add Uint64List-based block processing<br> <li> Optimize finalize with inlined avalanche</ul>


</details>


  </td>
  <td><a href="https://github.com/leonardocustodio/polkadart/pull/715/files#diff-925665fbe72ab04b477143db4e67cb21f5e1466e09d80fe435f05e43469a2087">+73/-102</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

